### PR TITLE
LazyType.load(): Replace __import__() with importlib.import_module()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [![CalVer](https://img.shields.io/badge/calver-YY.MINOR.MICRO-blue?style=flat-square)](https://calver.org/)
 
+## Dessine-moi 22.1.1 (2022-07-28)
+
+- `LazyType.load()`: Replace `__import__()` with `importlib.import_module()`
+  ({ghpr}`4`).
+
 ## Dessine-moi 22.1.0 (2022-07-19)
 
 ### Features

--- a/src/dessinemoi/_core.py
+++ b/src/dessinemoi/_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from collections.abc import MutableMapping
 from copy import copy
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
@@ -104,7 +105,7 @@ class LazyType:
         :return:
             Imported type.
         """
-        mod = __import__(self.mod)
+        mod = importlib.import_module(self.mod)
         return getattr(mod, self.attr)
 
 


### PR DESCRIPTION
This PR replaces usage of `__import__()` with `importlib.import_module()`, which is the recommended way to import a module by name.

Background: `__import__()` was returning a parent module when being called on a submodule. This led to unintended behaviour where requested attributes could not be resolved.