### PR TITLE
New aliasing system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 [![CalVer](https://img.shields.io/badge/calver-YY.MINOR.MICRO-blue?style=flat-square)](https://calver.org/)
 
-## Dessine-moi 22.1.1 (unreleased)
+## Dessine-moi 22.2.0 (unreleased)
+
+## Fixes and improvements
 
 - `LazyType.convert()`: Resolve lazy types ({ghpr}`5`).
+- `Factory`: New alias system ({ghpr}`6`).
+- `Factory.register()`: Rename `allow_id_overwrite` to `overwrite_id` ({ghpr}``6).
 
 ## Dessine-moi 22.1.1 (2022-07-28)
+
+### Fixes and improvements
 
 - `LazyType.load()`: Replace `__import__()` with `importlib.import_module()`
   ({ghpr}`4`).
@@ -36,7 +42,6 @@
 ### Features
 
 - `Factory.create()`: Add `construct` keyword argument ({ghcommit}`a2e5874`).
-
 
 ## Dessine-moi 21.1.0 (2021-06-02)
 

--- a/docs/rst/usage.rst
+++ b/docs/rst/usage.rst
@@ -67,25 +67,37 @@ class attribute to set the class's ID in the registry:
 .. note:: When used as a decorator, :meth:`~.Factory.register` is best used
    last (*i.e.* at the top of the sequence).
 
-The :meth:`~.Factory.register` method implements safeguards which can be
-bypassed with dedicated keyword arguments:
+By default, ID overwrite is not allowed. The ``overwrite_id`` parameter can be
+set to ``True`` to force the registration of a type with an existing ID.
 
-* if ``allow_aliases`` is ``True``, a type can be registered multiple times with
-  different IDs (the default value is ``False``):
-
-  .. doctest::
-
-     >>> factory.register(Sheep, type_id="mouton", allow_aliases=True)
-     <class '__main__.Sheep'>
-     >>> factory
-     Factory(registry={'sheep': FactoryRegistryEntry(cls=<class '__main__.Sheep'>, dict_constructor=None), 'lamb': FactoryRegistryEntry(cls=<class '__main__.Lamb'>, dict_constructor=None), 'mouton': FactoryRegistryEntry(cls=<class '__main__.Sheep'>, dict_constructor=None)})
-
-* if ``allow_id_overwrite`` is ``True``, registering a type with an existing ID
-  will succeed and overwrite the existing entry (the default value is ``False``).
-
-Finally, :meth:`~.Factory.register` features an optional ``dict_constructor``
+The :meth:`~.Factory.register` method features an optional ``dict_constructor``
 argument which, when set, associates a class method constructor to be called
 upon attempting dictionary conversion. See `Convert objects`_ for more detail.
+
+Alias registered types
+^^^^^^^^^^^^^^^^^^^^^^
+
+Having multiple IDs pointing to the same registered type may be useful as well.
+Types can be aliased after registration using the :meth:`~.Factory.alias`
+method:
+
+.. doctest::
+
+   >>> factory.alias("sheep", "mouton")
+   >>> factory
+   Factory(registry={'sheep': FactoryRegistryEntry(cls=<class '__main__.Sheep'>, dict_constructor=None), 'lamb': FactoryRegistryEntry(cls=<class '__main__.Lamb'>, dict_constructor=None), 'mouton': FactoryRegistryEntry(cls=<class '__main__.Sheep'>, dict_constructor=None)})
+
+Aliases may also be created using :meth:`~.Factory.register`'s ``aliases``
+keyword argument.
+
+.. doctest::
+
+   >>> del factory.registry["sheep"]
+   >>> del factory.registry["mouton"]
+   >>> factory.register(Sheep, type_id="sheep", aliases=["mouton"])
+   <class '__main__.Sheep'>
+   >>> factory
+   Factory(registry={'lamb': FactoryRegistryEntry(cls=<class '__main__.Lamb'>, dict_constructor=None), 'sheep': FactoryRegistryEntry(cls=<class '__main__.Sheep'>, dict_constructor=None), 'mouton': FactoryRegistryEntry(cls=<class '__main__.Sheep'>, dict_constructor=None)})
 
 Instantiate registered types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR modifies the alias system to provide a more convenient API which no longer requires chaining decorators. Changes are as follows:

* A new `Factory.alias()` method is introduced. It defines explicitly an alias to an existing entry.
* The `allow_aliases` param of `Factory.register()` is replaced by an `aliases` argument which takes a list of aliases pointing to the registered type.
* The `allow_id_overwrite` param of `Factory.register()` is renamed `overwrite_id`.